### PR TITLE
added support for .svelte files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "onLanguage:scss",
     "onLanguage:sass",
     "onLanguage:stylus",
-    "onLanguage:html"
+    "onLanguage:html",
+    "onLanguage:svelte"
   ],
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,7 @@ export function activate(context: vscode.ExtensionContext): void {
       { language: 'stylus' },
       { language: 'sass' },
       { language: 'html' },
+      { language: 'svelte' },
     ],
     {
       async provideCompletionItems(document: vscode.TextDocument, position: vscode.Position) {


### PR DESCRIPTION
Svelte components allow for inline styling. (see: [svelte styling example](https://svelte.dev/examples/styling)) When developing an extension using svelte, the `*.svelte` files do not feature code completion.
I simply added the `svelte `exsention to the language lists in `package.json `and `extensions.ts` and did a quick test.